### PR TITLE
Add JSON Schema for the LSDB object.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -308,6 +308,45 @@
         }
       ]
     },
+    "RefSeq": {
+      "description": "Database cross reference for reference sequence, can include other database cross-references and annotations.\n\nUse Genbank to source reference sequences.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "source",
+            "accession"
+          ]
+        },
+        {
+          "required": [
+            "uri"
+          ]
+        }
+      ]
+    },
     "SharingPolicy": {
       "description": "Data sharing policy and licensing.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -9,7 +9,7 @@
       "description": "List of database cross references.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/DbXRef"
+        "$ref": "#/$defs/DbXRef"
       },
       "uniqueItems": true
     },
@@ -17,14 +17,14 @@
       "description": "List of comments.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Comment"
+        "$ref": "#/$defs/Comment"
       }
     },
     "individuals": {
       "description": "List of individuals.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Individual"
+        "$ref": "#/$defs/Individual"
       },
       "minItems": 1,
       "uniqueItems": true
@@ -33,7 +33,7 @@
       "description": "List of panels.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Panel"
+        "$ref": "#/$defs/Panel"
       },
       "minItems": 1,
       "uniqueItems": true
@@ -42,13 +42,13 @@
       "description": "List of variants.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Variant"
+        "$ref": "#/$defs/Variant"
       },
       "minItems": 1,
       "uniqueItems": true
     },
     "source": {
-      "$ref": "#/definitions/Source"
+      "$ref": "#/$defs/Source"
     }
   },
   "additionalProperties": false,
@@ -76,7 +76,7 @@
       ]
     }
   ],
-  "definitions": {
+  "$defs": {
     "Comment": {
       "description": "A comment, which optionally can contain other comments.",
       "type": "object",
@@ -89,7 +89,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -97,14 +97,14 @@
           "description": "List of texts.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Text"
+            "$ref": "#/$defs/Text"
           }
         },
         "comments": {
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -143,26 +143,26 @@
           "enum": ["cDNA", "RNA", "AA"]
         },
         "ref_seq": {
-          "$ref": "#/definitions/RefSeq"
+          "$ref": "#/$defs/RefSeq"
         },
         "name": {
-          "$ref": "#/definitions/VariantName"
+          "$ref": "#/$defs/VariantName"
         },
         "gene": {
-          "$ref": "#/definitions/Gene"
+          "$ref": "#/$defs/Gene"
         },
         "pathogenicities": {
           "description": "List of variant classifications.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Pathogenicity"
+            "$ref": "#/$defs/Pathogenicity"
           }
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -170,14 +170,14 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "variant_detection": {
-          "$ref": "#/definitions/VariantDetection"
+          "$ref": "#/$defs/VariantDetection"
         },
         "seq_changes": {
-          "$ref": "#/definitions/SeqChanges"
+          "$ref": "#/$defs/SeqChanges"
         }
       },
       "additionalProperties": false,
@@ -233,7 +233,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -241,7 +241,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -274,7 +274,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -350,7 +350,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -358,7 +358,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -389,13 +389,13 @@
           "enum": ["0", "1", "2", "9"]
         },
         "description": {
-          "$ref": "#/definitions/Description"
+          "$ref": "#/$defs/Description"
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -403,7 +403,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -456,7 +456,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -464,7 +464,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -490,13 +490,13 @@
           "type": "string"
         },
         "gender": {
-          "$ref": "#/definitions/Gender"
+          "$ref": "#/$defs/Gender"
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -504,14 +504,14 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "phenotypes": {
           "description": "List of phenotypes for this individual.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Phenotype"
+            "$ref": "#/$defs/Phenotype"
           },
           "uniqueItems": true
         },
@@ -519,16 +519,16 @@
           "description": "List of variants detected in this individual.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Variant"
+            "$ref": "#/$defs/Variant"
           },
           "minItems": 1,
           "uniqueItems": true
         },
         "source": {
-          "$ref": "#/definitions/Source"
+          "$ref": "#/$defs/Source"
         },
         "sharing_policy": {
-          "$ref": "#/definitions/SharingPolicy"
+          "$ref": "#/$defs/SharingPolicy"
         }
       },
       "additionalProperties": false
@@ -557,7 +557,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -565,7 +565,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -605,13 +605,13 @@
           "enum": ["family", "extended family", "population"]
         },
         "gender": {
-          "$ref": "#/definitions/Gender"
+          "$ref": "#/$defs/Gender"
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -619,14 +619,14 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "individuals": {
           "description": "List of individuals in this panel.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Individual"
+            "$ref": "#/$defs/Individual"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -635,7 +635,7 @@
           "description": "List of phenotypes for this panel.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Phenotype"
+            "$ref": "#/$defs/Phenotype"
           },
           "uniqueItems": true
         },
@@ -643,16 +643,16 @@
           "description": "List of variants detected in this panel.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Variant"
+            "$ref": "#/$defs/Variant"
           },
           "minItems": 1,
           "uniqueItems": true
         },
         "source": {
-          "$ref": "#/definitions/Source"
+          "$ref": "#/$defs/Source"
         },
         "sharing_policy": {
-          "$ref": "#/definitions/SharingPolicy"
+          "$ref": "#/$defs/SharingPolicy"
         }
       },
       "additionalProperties": false
@@ -686,7 +686,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -694,14 +694,14 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "phenotypes": {
           "description": "List of phenotypes related to this pathogenicity.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Phenotype"
+            "$ref": "#/$defs/Phenotype"
           },
           "uniqueItems": true
         }
@@ -824,13 +824,13 @@
           "type": "string"
         },
         "inheritance_pattern": {
-          "$ref": "#/definitions/InheritancePattern"
+          "$ref": "#/$defs/InheritancePattern"
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -838,7 +838,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -896,7 +896,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -904,7 +904,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -951,13 +951,13 @@
           "enum": ["OpenAccess", "RestrictedAccess", "ClosedAccess"]
         },
         "use_permission": {
-          "$ref": "#/definitions/UsePermission"
+          "$ref": "#/$defs/UsePermission"
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -965,7 +965,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -1002,7 +1002,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -1010,14 +1010,14 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "variants": {
           "description": "List of related sequence changes.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConsVariant"
+            "$ref": "#/$defs/ConsVariant"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -1040,7 +1040,7 @@
           "description": "List of contact persons.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Contact"
+            "$ref": "#/$defs/Contact"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -1049,7 +1049,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -1141,7 +1141,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -1149,7 +1149,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },
@@ -1186,16 +1186,16 @@
           "enum": ["DNA"]
         },
         "ref_seq": {
-          "$ref": "#/definitions/RefSeq"
+          "$ref": "#/$defs/RefSeq"
         },
         "name": {
-          "$ref": "#/definitions/VariantName"
+          "$ref": "#/$defs/VariantName"
         },
         "genes": {
           "description": "List of genes overlapping with this variant.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Gene"
+            "$ref": "#/$defs/Gene"
           },
           "uniqueItems": true
         },
@@ -1203,14 +1203,14 @@
           "description": "List of variant classifications.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Pathogenicity"
+            "$ref": "#/$defs/Pathogenicity"
           }
         },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -1218,26 +1218,26 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         },
         "variant_detection": {
           "description": "List of assays used to screen the individual for variants.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/VariantDetection"
+            "$ref": "#/$defs/VariantDetection"
           },
           "minItems": 1,
           "uniqueItems": true
         },
         "seq_changes": {
-          "$ref": "#/definitions/SeqChanges"
+          "$ref": "#/$defs/SeqChanges"
         },
         "source": {
-          "$ref": "#/definitions/Source"
+          "$ref": "#/$defs/Source"
         },
         "sharing_policy": {
-          "$ref": "#/definitions/SharingPolicy"
+          "$ref": "#/$defs/SharingPolicy"
         }
       },
       "additionalProperties": false,
@@ -1349,7 +1349,7 @@
           "description": "List of database cross references.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DbXRef"
+            "$ref": "#/$defs/DbXRef"
           },
           "uniqueItems": true
         },
@@ -1357,7 +1357,7 @@
           "description": "List of comments.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Comment"
+            "$ref": "#/$defs/Comment"
           }
         }
       },

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -648,6 +648,37 @@
         }
       ]
     },
+    "Text": {
+      "description": "Object to represent a piece of text.",
+      "type": "object",
+      "properties": {
+        "content_type": {
+          "description": "The content-type of this text.",
+          "type": "string",
+          "enum": ["text/plain", "text/html"],
+          "default": "text/plain"
+        },
+        "encoding": {
+          "description": "Character encoding of this text.",
+          "type": "string",
+          "enum": ["ISO-8859-1", "UTF-8"],
+          "default": "UTF-8"
+        },
+        "lang": {
+          "description": "Language used in this text, using ISO 639-1 values.",
+          "type": "string",
+          "default": "en"
+        },
+        "value": {
+          "description": "The actual value of the text.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "value"
+      ]
+    },
     "UsePermission": {
       "description": "Licensing information.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -509,6 +509,71 @@
         }
       ]
     },
+    "Panel": {
+      "description": "An unspecified group of individuals.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier for this entry.",
+          "type": "string"
+        },
+        "size": {
+          "description": "The number of individuals in this panel.",
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "type": {
+          "description": "The type of panel; family, extended family, or a population.",
+          "type": "string",
+          "enum": ["family", "extended family", "population"]
+        },
+        "gender": {
+          "$ref": "#/definitions/Gender"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        },
+        "individuals": {
+          "description": "List of individuals in this panel.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Individual"
+          }
+        },
+        "phenotypes": {
+          "description": "List of phenotypes for this panel.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Phenotype"
+          }
+        },
+        "variants": {
+          "description": "List of variants detected in this panel.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Variant"
+          }
+        },
+        "source": {
+          "$ref": "#/definitions/Source"
+        },
+        "sharing_policy": {
+          "$ref": "#/definitions/SharingPolicy"
+        }
+      },
+      "additionalProperties": false
+    },
     "Pathogenicity": {
       "description": "The pathogenicity of a variant, optionally related to certain phenotypes.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -57,7 +57,7 @@
           "type": "string"
         },
         "accession": {
-          "description": "The ID of a relevant entry in an external resource.",
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
           "type": "string"
         },
         "name": {
@@ -70,17 +70,35 @@
         }
       },
       "additionalProperties": false,
-      "anyOf": [
+      "allOf": [
         {
-          "required": [
-            "source",
-            "accession"
+          "anyOf": [
+            {
+              "required": [
+                "source",
+                "accession"
+              ]
+            },
+            {
+              "required": [
+                "name",
+                "uri"
+              ]
+            }
           ]
         },
         {
-          "required": [
-            "name",
-            "uri"
+          "anyOf": [
+            {
+              "not": {
+                "required": ["accession"]
+              }
+            },
+            {
+              "required": [
+                "source"
+              ]
+            }
           ]
         }
       ],
@@ -112,7 +130,7 @@
           "type": "string"
         },
         "accession": {
-          "description": "The ID of a relevant entry in an external resource.",
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
           "type": "string"
         },
         "uri": {
@@ -130,6 +148,18 @@
       "additionalProperties": false,
       "required": [
         "term"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "required": ["accession"]
+          }
+        },
+        {
+          "required": [
+            "source"
+          ]
+        }
       ]
     },
     "Gender": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -11,6 +11,61 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "Comment": {
+      "description": "A comment, which optionally can contain other comments.",
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "texts": {
+          "description": "List of texts.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Text"
+          }
+        },
+        "comments": {
+          "default": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "examples": [
+        {
+          "texts": [
+            {
+              "value": "Shows residual enzyme activity"
+            }
+          ]
+        },
+        {
+          "texts": [
+            {
+              "content_type": "text/plain",
+              "lang": "en",
+              "value": "7 heterozygous, no homozygous found in gnomAD v.2.1.1."
+            },
+            {
+              "content_type": "text/html",
+              "lang": "en",
+              "value": "7 heterozygous, no homozygous found in <A href=\"https://gnomad.broadinstitute.org/region/15-40702898-40702898?dataset=gnomad_r2_1\">gnomAD v.2.1.1</A>."
+            }
+          ]
+        }
+      ]
+    },
     "Contact": {
       "description": "A contact person, containing a name and other contact information.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -505,6 +505,26 @@
           ]
         }
       ]
+    },
+    "VariantName": {
+      "description": "The variant description, typically in HGVS.",
+      "type": "object",
+      "properties": {
+        "scheme": {
+          "description": "The naming scheme of the variant; HGVS or ISCN.",
+          "type": "string",
+          "enum": ["HGVS", "ISCN"]
+        },
+        "value": {
+          "description": "The actual variant description.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "scheme",
+        "value"
+      ]
     }
   }
 }

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -33,10 +33,53 @@
         "email": {
           "description": "The email address of the contact person.",
           "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
         }
       },
       "required": [
         "name"
+      ]
+    },
+    "DbXRef": {
+      "description": "Database cross reference.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Name of the external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of the relevant entry in the external resource.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name to display for this reference.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to the relevant entry in the external resource.",
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "source",
+            "accession"
+          ]
+        },
+        {
+          "required": [
+            "name",
+            "uri"
+          ]
+        }
       ]
     },
     "Source": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -255,6 +255,51 @@
         }
       ]
     },
+    "SharingPolicy": {
+      "description": "Data sharing policy and licensing.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The access policy type. Options are taken from: http://purl.org/eprint/accessRights/",
+          "type": "string",
+          "enum": ["OpenAccess", "RestrictedAccess", "ClosedAccess"]
+        },
+        "use_permission": {
+          "$ref": "#/definitions/UsePermission"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "examples": [
+        {
+          "type": "OpenAccess",
+          "use_permission": {
+            "term": "Creative Commons Attribution 4.0 International",
+            "source": "CC",
+            "accession": "cc_by_4.0",
+            "uri": "https://creativecommons.org/licenses/by/4.0/"
+          }
+        },
+        {
+          "type": "RestrictedAccess",
+          "use_permission": {
+            "term": "Creative Commons Attribution-ShareAlike 4.0 International",
+            "source": "CC",
+            "accession": "cc_by-sa_4.0",
+            "uri": "https://creativecommons.org/licenses/by-sa/4.0/"
+          }
+        }
+      ]
+    },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -80,6 +80,16 @@
             "uri"
           ]
         }
+      ],
+      "examples": [
+        {
+          "source": "pubmed",
+          "accession": "23031277"
+        },
+        {
+          "name": "Byrne et al (2012)",
+          "uri": "https://pubmed.ncbi.nlm.nih.gov/23031277/"
+        }
       ]
     },
     "Source": {
@@ -110,6 +120,25 @@
           "required": [
             "contacts"
           ]
+        }
+      ],
+      "examples": [
+        {
+          "source": {
+            "contacts": [
+              {
+                "role": "submitter",
+                "name": "Ivo F.A.C. Fokkema",
+                "email": "I.F.A.C.Fokkema@LUMC.nl",
+                "db_xrefs": [
+                  {
+                    "source": "orcid",
+                    "accession": "0000-0002-1368-1939"
+                  }
+                ]
+              }
+            ]
+          }
         }
       ]
     }

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -263,6 +263,9 @@
           "description": "URI to a relevant entry in an external resource.",
           "type": "string"
         },
+        "inheritance_pattern": {
+          "$ref": "#/definitions/InheritancePattern"
+        },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",
@@ -291,7 +294,12 @@
         {
           "term": "isovaleric acidemia (IVA)",
           "source": "OMIM",
-          "accession": "243500"
+          "accession": "243500",
+          "inheritance_pattern": {
+            "term": "familial, autosomal recessive",
+            "source": "HPO",
+            "accession": "0000007"
+          }
         },
         {
           "term": "Metabolic acidosis",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -128,6 +128,41 @@
         "term"
       ]
     },
+    "Gender": {
+      "description": "The gender of an individual.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "ISO 5218 gender codes; 0, 1, 2, or 9 ('unknown', 'male', 'female', or 'not applicable').",
+          "type": "string",
+          "enum": ["0", "1", "2", "9"]
+        },
+        "description": {
+          "$ref": "#/definitions/Description"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "required": [
+        "code"
+      ],
+      "examples": [
+        {
+          "code": "1"
+        },
+        {
+          "code": "9",
+          "description": {
+            "term": "XX-male"
+          }
+        }
+      ]
+    },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
       "type" : "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -96,6 +96,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -122,6 +129,13 @@
         "uri": {
           "description": "URI to a relevant entry in an external resource.",
           "type": "string"
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -198,6 +212,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -234,6 +255,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
           }
         }
       },
@@ -288,6 +316,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -328,6 +363,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
           }
         }
       },
@@ -378,6 +420,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
           }
         },
         "phenotypes": {
@@ -514,6 +563,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -572,6 +628,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -625,6 +688,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -668,6 +738,13 @@
           },
           "minItems": 1,
           "uniqueItems": true
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -760,6 +837,13 @@
           "items": {
             "$ref": "#/definitions/DbXRef"
           }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
         }
       },
       "additionalProperties": false,
@@ -797,6 +881,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
           }
         }
       },

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -293,6 +293,111 @@
         }
       ]
     },
+    "Pathogenicity": {
+      "description": "The pathogenicity of a variant, optionally related to certain phenotypes.",
+      "type": "object",
+      "properties": {
+        "scope": {
+          "description": "The scope in which the pathogenicity was determined.",
+          "type": "string",
+          "enum": ["individual", "family", "population"]
+        },
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "phenotypes": {
+          "description": "List of phenotypes related to this pathogenicity.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Phenotype"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "not": {
+                "required": ["accession"]
+              }
+            },
+            {
+              "required": [
+                "source"
+              ]
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "not": {
+                "required": ["source"]
+              },
+              "properties": {
+                "term": {
+                  "enum": ["unclassified", "benign", "likely benign", "VUS", "likely pathogenic", "pathogenic", "association"]
+                }
+              }
+            },
+            {
+              "properties": {
+                "source": {
+                  "enum": ["G2P"]
+                },
+                "term": {
+                  "enum": ["Unclassified", "Non-pathogenic", "Probably not pathogenic", "Not known", "Probably pathogenic", "Pathogenic"]
+                }
+              }
+            },
+            {
+              "properties": {
+                "source": {
+                  "enum": ["ACMG"]
+                },
+                "term": {
+                  "enum": ["benign", "likely benign", "uncertain significance", "likely pathogenic", "pathogenic"]
+                }
+              }
+            },
+            {
+              "properties": {
+                "source": {
+                  "enum": ["ENIGMA"]
+                },
+                "term": {
+                  "enum": ["Class 1", "Class 2", "Class 3", "Class 4", "Class 5"]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
     "Phenotype": {
       "description": "A phenotype of an individual.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -279,35 +279,20 @@
         }
       },
       "additionalProperties": false,
-      "allOf": [
+      "dependencies": {
+        "accession": "source"
+      },
+      "anyOf": [
         {
-          "anyOf": [
-            {
-              "required": [
-                "source",
-                "accession"
-              ]
-            },
-            {
-              "required": [
-                "name",
-                "uri"
-              ]
-            }
+          "required": [
+            "source",
+            "accession"
           ]
         },
         {
-          "anyOf": [
-            {
-              "not": {
-                "required": ["accession"]
-              }
-            },
-            {
-              "required": [
-                "source"
-              ]
-            }
+          "required": [
+            "name",
+            "uri"
           ]
         }
       ],
@@ -366,18 +351,9 @@
       "required": [
         "term"
       ],
-      "anyOf": [
-        {
-          "not": {
-            "required": ["accession"]
-          }
-        },
-        {
-          "required": [
-            "source"
-          ]
-        }
-      ]
+      "dependencies": {
+        "accession": "source"
+      }
     },
     "Gender": {
       "description": "The gender of an individual.",
@@ -469,6 +445,9 @@
         }
       },
       "additionalProperties": false,
+      "dependencies": {
+        "accession": "source"
+      },
       "examples": [
         {
           "source": "HGNC",
@@ -573,18 +552,9 @@
       "required": [
         "term"
       ],
-      "anyOf": [
-        {
-          "not": {
-            "required": ["accession"]
-          }
-        },
-        {
-          "required": [
-            "source"
-          ]
-        }
-      ]
+      "dependencies": {
+        "accession": "source"
+      }
     },
     "Panel": {
       "description": "An unspecified group of individuals.",
@@ -710,73 +680,58 @@
       "required": [
         "term"
       ],
-      "allOf": [
+      "dependencies": {
+        "accession": "source"
+      },
+      "oneOf": [
         {
-          "anyOf": [
-            {
-              "not": {
-                "required": ["accession"]
-              }
-            },
-            {
-              "required": [
-                "source"
-              ]
+          "not": {
+            "required": ["source"]
+          },
+          "properties": {
+            "term": {
+              "enum": ["unclassified", "benign", "likely benign", "VUS", "likely pathogenic", "pathogenic", "association"]
             }
-          ]
+          }
         },
         {
-          "oneOf": [
-            {
-              "not": {
-                "required": ["source"]
-              },
-              "properties": {
-                "term": {
-                  "enum": ["unclassified", "benign", "likely benign", "VUS", "likely pathogenic", "pathogenic", "association"]
-                }
-              }
+          "required": [
+            "source"
+          ],
+          "properties": {
+            "source": {
+              "enum": ["G2P"]
             },
-            {
-              "required": [
-                "source"
-              ],
-              "properties": {
-                "source": {
-                  "enum": ["G2P"]
-                },
-                "term": {
-                  "enum": ["Unclassified", "Non-pathogenic", "Probably not pathogenic", "Not known", "Probably pathogenic", "Pathogenic"]
-                }
-              }
-            },
-            {
-              "required": [
-                "source"
-              ],
-              "properties": {
-                "source": {
-                  "enum": ["ACMG"]
-                },
-                "term": {
-                  "enum": ["benign", "likely benign", "uncertain significance", "likely pathogenic", "pathogenic"]
-                }
-              }
-            },
-            {
-              "required": [
-                "source"
-              ],
-              "properties": {
-                "source": {
-                  "enum": ["ENIGMA"]
-                },
-                "term": {
-                  "enum": ["Class 1", "Class 2", "Class 3", "Class 4", "Class 5"]
-                }
-              }
+            "term": {
+              "enum": ["Unclassified", "Non-pathogenic", "Probably not pathogenic", "Not known", "Probably pathogenic", "Pathogenic"]
             }
-          ]
+          }
+        },
+        {
+          "required": [
+            "source"
+          ],
+          "properties": {
+            "source": {
+              "enum": ["ACMG"]
+            },
+            "term": {
+              "enum": ["benign", "likely benign", "uncertain significance", "likely pathogenic", "pathogenic"]
+            }
+          }
+        },
+        {
+          "required": [
+            "source"
+          ],
+          "properties": {
+            "source": {
+              "enum": ["ENIGMA"]
+            },
+            "term": {
+              "enum": ["Class 1", "Class 2", "Class 3", "Class 4", "Class 5"]
+            }
+          }
         }
       ],
       "examples": [
@@ -846,18 +801,9 @@
       "required": [
         "term"
       ],
-      "anyOf": [
-        {
-          "not": {
-            "required": ["accession"]
-          }
-        },
-        {
-          "required": [
-            "source"
-          ]
-        }
-      ],
+      "dependencies": {
+        "accession": "source"
+      },
       "examples": [
         {
           "term": "isovaleric acidemia (IVA)",
@@ -909,34 +855,19 @@
         }
       },
       "additionalProperties": false,
-      "allOf": [
+      "dependencies": {
+        "accession": "source"
+      },
+      "anyOf": [
         {
-          "anyOf": [
-            {
-              "required": [
-                "source",
-                "accession"
-              ]
-            },
-            {
-              "required": [
-                "uri"
-              ]
-            }
+          "required": [
+            "source",
+            "accession"
           ]
         },
         {
-          "anyOf": [
-            {
-              "not": {
-                "required": ["accession"]
-              }
-            },
-            {
-              "required": [
-                "source"
-              ]
-            }
+          "required": [
+            "uri"
           ]
         }
       ]
@@ -1157,18 +1088,9 @@
       "required": [
         "term"
       ],
-      "anyOf": [
-        {
-          "not": {
-            "required": ["accession"]
-          }
-        },
-        {
-          "required": [
-            "source"
-          ]
-        }
-      ]
+      "dependencies": {
+        "accession": "source"
+      }
     },
     "Variant": {
       "description": "A genomic variant.",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -5,8 +5,8 @@
   "description": "An LSDB object holds one or more data submissions based around either individuals, their phenotypes, and their variants, or a summary submission of just variant data.",
   "type": "object",
   "properties": {
-    "source" : {
-      "$ref" : "#/definitions/Source"
+    "source": {
+      "$ref": "#/definitions/Source"
     }
   },
   "additionalProperties": false,
@@ -257,7 +257,7 @@
     },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
-      "type" : "object",
+      "type": "object",
       "properties": {
         "name": {
           "description": "The name of the data source.",
@@ -303,6 +303,51 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "UsePermission": {
+      "description": "Licensing information.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The name of the license.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "required": ["accession"]
+          }
+        },
+        {
+          "required": [
+            "source"
+          ]
         }
       ]
     }

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -365,6 +365,9 @@
               }
             },
             {
+              "required": [
+                "source"
+              ],
               "properties": {
                 "source": {
                   "enum": ["G2P"]
@@ -375,6 +378,9 @@
               }
             },
             {
+              "required": [
+                "source"
+              ],
               "properties": {
                 "source": {
                   "enum": ["ACMG"]
@@ -385,6 +391,9 @@
               }
             },
             {
+              "required": [
+                "source"
+              ],
               "properties": {
                 "source": {
                   "enum": ["ENIGMA"]

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -793,6 +793,38 @@
         }
       ]
     },
+    "SeqChanges": {
+      "description": "Object describing a recursive list of related sequence changes on overlapping sequence levels and features.",
+      "type": "object",
+      "properties": {
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        },
+        "variants": {
+          "description": "List of related sequence changes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConsVariant"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "variants"
+      ]
+    },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -198,6 +198,56 @@
         }
       ]
     },
+    "Gene": {
+      "description": "A representation of a gene, identified by its HGNC symbol or ID.\n\nCan include other database cross-references and annotations.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string",
+          "enum": ["HGNC"]
+        },
+        "accession": {
+          "description": "The ID or symbol of the gene in the HGNC database.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            }
+          ]
+        },
+        "name": {
+          "description": "Gene name",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "examples": [
+        {
+          "source": "HGNC",
+          "accession": "BRCA1"
+        },
+        {
+          "source": "HGNC",
+          "accession": "1100",
+          "name": "BRCA1 DNA repair associated"
+        }
+      ]
+    },
     "InheritancePattern": {
       "description": "The inheritance pattern of a phenotype.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -966,6 +966,165 @@
         }
       ]
     },
+    "Variant": {
+      "description": "A genomic variant.",
+      "type": "object",
+      "properties": {
+        "copy_count": {
+          "description": "Copy count of this variant, 2 for homozygous, 1 for heterozygous, decimals allowed for somatic variants.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 2
+        },
+        "type": {
+          "description": "Type of variant (DNA, cDNA, RNA, AA). For genomic variants, only 'DNA' is allowed.",
+          "type": "string",
+          "enum": ["DNA"]
+        },
+        "ref_seq": {
+          "$ref": "#/definitions/RefSeq"
+        },
+        "name": {
+          "$ref": "#/definitions/VariantName"
+        },
+        "genes": {
+          "description": "List of genes overlapping with this variant.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Gene"
+          }
+        },
+        "pathogenicities": {
+          "description": "List of variant classifications.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Pathogenicity"
+          }
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        },
+        "variant_detection": {
+          "description": "List of assays used to screen the individual for variants.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VariantDetection"
+          },
+          "minItems": 1
+        },
+        "seq_changes": {
+          "$ref": "#/definitions/SeqChanges"
+        },
+        "source": {
+          "$ref": "#/definitions/Source"
+        },
+        "sharing_policy": {
+          "$ref": "#/definitions/SharingPolicy"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name"
+      ],
+      "examples": [
+        {
+          "copy_count": 1,
+          "type": "DNA",
+          "ref_seq": {
+            "source": "genbank",
+            "accession": "NC_000015.9"
+          },
+          "name": {
+            "scheme": "HGVS",
+            "value": "g.40707653C>T"
+          },
+          "pathogenicities": [
+            {
+              "scope": "individual",
+              "term": "likely pathogenic"
+            }
+          ],
+          "comments": [
+            {
+              "texts": [
+                {
+                  "value": "Shows residual enzyme activity"
+                }
+              ]
+            }
+          ],
+          "db_xrefs": [
+            {
+              "source": "dbsnp",
+              "accession": "rs28940889"
+            }
+          ],
+          "variant_detection": [
+            {
+              "template": "DNA",
+              "technique": "SEQ"
+            },
+            {
+              "template": "RNA",
+              "technique": "RT-PCR"
+            }
+          ],
+          "seq_changes": {
+            "variants": [
+              {
+                "type": "cDNA",
+                "gene": {
+                  "source": "HGNC",
+                  "accession": "IVD"
+                },
+                "ref_seq": {
+                  "source": "genbank",
+                  "accession": "NM_002225.3"
+                },
+                "name": {
+                  "scheme": "HGVS",
+                  "value": "c.941C>T"
+                },
+                "seq_changes": {
+                  "variants": [
+                    {
+                      "type": "RNA",
+                      "name": {
+                        "scheme": "HGVS",
+                        "value": "r.941c>u"
+                      },
+                      "seq_changes": {
+                        "variants": [
+                          {
+                            "type": "AA",
+                            "name": {
+                              "scheme": "HGVS",
+                              "value": "p.Ala314Val"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "VariantDetection": {
       "description": "The technique(s) that were used to detect the variant.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -10,7 +10,8 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/DbXRef"
-      }
+      },
+      "uniqueItems": true
     },
     "comments": {
       "description": "List of comments.",
@@ -25,7 +26,8 @@
       "items": {
         "$ref": "#/definitions/Individual"
       },
-      "minItems": 1
+      "minItems": 1,
+      "uniqueItems": true
     },
     "panels": {
       "description": "List of panels.",
@@ -33,7 +35,8 @@
       "items": {
         "$ref": "#/definitions/Panel"
       },
-      "minItems": 1
+      "minItems": 1,
+      "uniqueItems": true
     },
     "variants": {
       "description": "List of variants.",
@@ -41,7 +44,8 @@
       "items": {
         "$ref": "#/definitions/Variant"
       },
-      "minItems": 1
+      "minItems": 1,
+      "uniqueItems": true
     },
     "source": {
       "$ref": "#/definitions/Source"
@@ -86,7 +90,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "texts": {
           "description": "List of texts.",
@@ -158,7 +163,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -228,7 +234,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -344,7 +351,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -388,7 +396,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -448,7 +457,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -487,7 +497,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -501,14 +512,16 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Phenotype"
-          }
+          },
+          "uniqueItems": true
         },
         "variants": {
           "description": "List of variants detected in this individual.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Variant"
-          }
+          },
+          "uniqueItems": true
         },
         "source": {
           "$ref": "#/definitions/Source"
@@ -544,7 +557,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -597,7 +611,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -611,21 +626,24 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Individual"
-          }
+          },
+          "uniqueItems": true
         },
         "phenotypes": {
           "description": "List of phenotypes for this panel.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Phenotype"
-          }
+          },
+          "uniqueItems": true
         },
         "variants": {
           "description": "List of variants detected in this panel.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Variant"
-          }
+          },
+          "uniqueItems": true
         },
         "source": {
           "$ref": "#/definitions/Source"
@@ -666,7 +684,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -680,7 +699,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Phenotype"
-          }
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false,
@@ -808,7 +828,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -873,7 +894,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -933,7 +955,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -977,7 +1000,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -992,7 +1016,8 @@
           "items": {
             "$ref": "#/definitions/ConsVariant"
           },
-          "minItems": 1
+          "minItems": 1,
+          "uniqueItems": true
         }
       },
       "additionalProperties": false,
@@ -1114,7 +1139,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -1167,7 +1193,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Gene"
-          }
+          },
+          "uniqueItems": true
         },
         "pathogenicities": {
           "description": "List of variant classifications.",
@@ -1181,7 +1208,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",
@@ -1196,7 +1224,8 @@
           "items": {
             "$ref": "#/definitions/VariantDetection"
           },
-          "minItems": 1
+          "minItems": 1,
+          "uniqueItems": true
         },
         "seq_changes": {
           "$ref": "#/definitions/SeqChanges"
@@ -1318,7 +1347,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/DbXRef"
-          }
+          },
+          "uniqueItems": true
         },
         "comments": {
           "description": "List of comments.",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -9,6 +9,7 @@
       "$ref" : "#/definitions/Source"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Contact": {
       "description": "A contact person, containing a name and other contact information.",
@@ -42,6 +43,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "name"
       ]
@@ -67,6 +69,7 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "anyOf": [
         {
           "required": [
@@ -124,6 +127,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "term"
       ]
@@ -148,6 +152,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "code"
       ],
@@ -181,6 +186,7 @@
           "uniqueItems": true
         }
       },
+      "additionalProperties": false,
       "anyOf": [
         {
           "required": [

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -333,16 +333,34 @@
         }
       },
       "additionalProperties": false,
-      "anyOf": [
+      "allOf": [
         {
-          "required": [
-            "source",
-            "accession"
+          "anyOf": [
+            {
+              "required": [
+                "source",
+                "accession"
+              ]
+            },
+            {
+              "required": [
+                "uri"
+              ]
+            }
           ]
         },
         {
-          "required": [
-            "uri"
+          "anyOf": [
+            {
+              "not": {
+                "required": ["accession"]
+              }
+            },
+            {
+              "required": [
+                "source"
+              ]
+            }
           ]
         }
       ]

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -34,7 +34,7 @@
           }
         },
         "comments": {
-          "default": "List of comments.",
+          "description": "List of comments.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Comment"

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -693,6 +693,43 @@
         }
       ]
     },
+    "VariantDetection": {
+      "description": "The technique(s) that were used to detect the variant.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "description": "The template on which the variant was detected.",
+          "type": "string",
+          "enum": ["DNA", "RNA", "protein"]
+        },
+        "technique": {
+          "description": "The detection method.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "template",
+        "technique"
+      ],
+      "examples": [
+        {
+          "template": "DNA",
+          "technique": "SEQ"
+        },
+        {
+          "template": "RNA",
+          "technique": "RT-PCR"
+        }
+      ]
+    },
     "VariantName": {
       "description": "The variant description, typically in HGVS.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -5,11 +5,73 @@
   "description": "An LSDB object holds one or more data submissions based around either individuals, their phenotypes, and their variants, or a summary submission of just variant data.",
   "type": "object",
   "properties": {
+    "db_xrefs": {
+      "description": "List of database cross references.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DbXRef"
+      }
+    },
+    "comments": {
+      "description": "List of comments.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Comment"
+      }
+    },
+    "individuals": {
+      "description": "List of individuals.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Individual"
+      },
+      "minItems": 1
+    },
+    "panels": {
+      "description": "List of panels.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Panel"
+      },
+      "minItems": 1
+    },
+    "variants": {
+      "description": "List of variants.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Variant"
+      },
+      "minItems": 1
+    },
     "source": {
       "$ref": "#/definitions/Source"
     }
   },
   "additionalProperties": false,
+  "required": [
+    "source"
+  ],
+  "oneOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "individuals"
+          ]
+        },
+        {
+          "required": [
+            "panels"
+          ]
+        }
+      ]
+    },
+    {
+      "required": [
+        "variants"
+      ]
+    }
+  ],
   "definitions": {
     "Comment": {
       "description": "A comment, which optionally can contain other comments.",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -12,7 +12,32 @@
   "definitions": {
     "Contact": {
       "description": "A contact person, containing a name and other contact information.",
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "role": {
+          "description": "The role of this contact person, like submitter or data owner.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the contact person.",
+          "type": "string"
+        },
+        "address": {
+          "description": "The address of the contact person.",
+          "type": "string"
+        },
+        "phone": {
+          "description": "The phone number of the contact person.",
+          "type": "string"
+        },
+        "email": {
+          "description": "The email address of the contact person.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
     },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -51,11 +51,11 @@
       "type": "object",
       "properties": {
         "source": {
-          "description": "Name of the external resource.",
+          "description": "Name of an external resource.",
           "type": "string"
         },
         "accession": {
-          "description": "The ID of the relevant entry in the external resource.",
+          "description": "The ID of a relevant entry in an external resource.",
           "type": "string"
         },
         "name": {
@@ -63,7 +63,7 @@
           "type": "string"
         },
         "uri": {
-          "description": "URI to the relevant entry in the external resource.",
+          "description": "URI to a relevant entry in an external resource.",
           "type": "string"
         }
       },
@@ -90,6 +90,42 @@
           "name": "Byrne et al (2012)",
           "uri": "https://pubmed.ncbi.nlm.nih.gov/23031277/"
         }
+      ]
+    },
+    "Description": {
+      "description": "A description more closely explaining another value.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element that a Description has been added to.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A longer description of the term.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "required": [
+        "term"
       ]
     },
     "Source": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -405,6 +405,29 @@
             }
           ]
         }
+      ],
+      "examples": [
+        {
+          "scope": "individual",
+          "term": "likely pathogenic",
+          "phenotypes": [
+            {
+              "term": "isovaleric acidemia (IVA)",
+              "source": "OMIM",
+              "accession": "243500"
+            }
+          ]
+        },
+        {
+          "scope": "individual",
+          "source": "ACMG",
+          "term": "pathogenic"
+        },
+        {
+          "scope": "family",
+          "source": "ENIGMA",
+          "term": "Class 4"
+        }
       ]
     },
     "Phenotype": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -3,5 +3,47 @@
   "$id": "https://github.com/VarioML/VarioML/json/schemas/v.2.0/LSDB.json",
   "title": "Locus Specific Database (LSDB)",
   "description": "An LSDB object holds one or more data submissions based around either individuals, their phenotypes, and their variants, or a summary submission of just variant data.",
-  "type": "object"
+  "type": "object",
+  "properties": {
+    "source" : {
+      "$ref" : "#/definitions/Source"
+    }
+  },
+  "definitions": {
+    "Contact": {
+      "description": "A contact person, containing a name and other contact information.",
+      "type": "object"
+    },
+    "Source": {
+      "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
+      "type" : "object",
+      "properties": {
+        "name": {
+          "description": "The name of the data source.",
+          "type": "string"
+        },
+        "contacts": {
+          "description": "List of contact persons.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Contact"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "required": [
+            "contacts"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -521,6 +521,7 @@
           "items": {
             "$ref": "#/definitions/Variant"
           },
+          "minItems": 1,
           "uniqueItems": true
         },
         "source": {
@@ -627,6 +628,7 @@
           "items": {
             "$ref": "#/definitions/Individual"
           },
+          "minItems": 1,
           "uniqueItems": true
         },
         "phenotypes": {
@@ -643,6 +645,7 @@
           "items": {
             "$ref": "#/definitions/Variant"
           },
+          "minItems": 1,
           "uniqueItems": true
         },
         "source": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -66,6 +66,77 @@
         }
       ]
     },
+    "ConsVariant": {
+      "description": "A related sequence change on an overlapping sequence level.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Type of variant (cDNA, RNA, AA).",
+          "type": "string",
+          "enum": ["cDNA", "RNA", "AA"]
+        },
+        "ref_seq": {
+          "$ref": "#/definitions/RefSeq"
+        },
+        "name": {
+          "$ref": "#/definitions/VariantName"
+        },
+        "gene": {
+          "$ref": "#/definitions/Gene"
+        },
+        "pathogenicities": {
+          "description": "List of variant classifications.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Pathogenicity"
+          }
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        },
+        "variant_detection": {
+          "$ref": "#/definitions/VariantDetection"
+        },
+        "seq_changes": {
+          "$ref": "#/definitions/SeqChanges"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "name"
+      ],
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": ["cDNA"]
+            }
+          },
+          "required": [
+            "ref_seq"
+          ]
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": ["RNA", "AA"]
+            }
+          }
+        }
+      ]
+    },
     "Contact": {
       "description": "A contact person, containing a name and other contact information.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/VarioML/VarioML/json/schemas/v.2.0/LSDB.json",
+  "title": "Locus Specific Database (LSDB)",
+  "description": "An LSDB object holds one or more data submissions based around either individuals, their phenotypes, and their variants, or a summary submission of just variant data.",
+  "type": "object"
+}

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -198,6 +198,51 @@
         }
       ]
     },
+    "InheritancePattern": {
+      "description": "The inheritance pattern of a phenotype.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "required": ["accession"]
+          }
+        },
+        {
+          "required": [
+            "source"
+          ]
+        }
+      ]
+    },
     "Phenotype": {
       "description": "A phenotype of an individual.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -198,6 +198,63 @@
         }
       ]
     },
+    "Phenotype": {
+      "description": "A phenotype of an individual.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "required": ["accession"]
+          }
+        },
+        {
+          "required": [
+            "source"
+          ]
+        }
+      ],
+      "examples": [
+        {
+          "term": "isovaleric acidemia (IVA)",
+          "source": "OMIM",
+          "accession": "243500"
+        },
+        {
+          "term": "Metabolic acidosis",
+          "source": "HPO",
+          "accession": "0001942"
+        }
+      ]
+    },
     "Source": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
       "type" : "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -409,6 +409,54 @@
         }
       ]
     },
+    "Individual": {
+      "description": "A patient or other individual.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier for this entry.",
+          "type": "string"
+        },
+        "gender": {
+          "$ref": "#/definitions/Gender"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DbXRef"
+          }
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Comment"
+          }
+        },
+        "phenotypes": {
+          "description": "List of phenotypes for this individual.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Phenotype"
+          }
+        },
+        "variants": {
+          "description": "List of variants detected in this individual.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Variant"
+          }
+        },
+        "source": {
+          "$ref": "#/definitions/Source"
+        },
+        "sharing_policy": {
+          "$ref": "#/definitions/SharingPolicy"
+        }
+      },
+      "additionalProperties": false
+    },
     "InheritancePattern": {
       "description": "The inheritance pattern of a phenotype.",
       "type": "object",


### PR DESCRIPTION
Add JSON Schema (draft 7) for the LSDB object.
- Reconverted the VarioML-XML Schema into native VarioML-JSON Schema. Not all fields have been copied, this Schema will be expanded later but represents a good minimum requirement.
- JSON Schema allows for more granular requirements, e.g. allowing different `terms` depending on the `source` or requiring one of `individuals`, `panels`, or `variants`. These requirements have been added to VarioML-JSON while not being present in VarioML-XML.
- JSON Schema allows for examples, so several objects have examples included (`Comment`, `DbXRef`, `Gender`, `Gene`, `Pathogenicity`, `Phenotype`, `SharingPolicy`, `Source`, `Variant`, and `VariantDetection`).
- HTML documentation will be generated based on this Schema and added to the GitHub pages.