### PR TITLE
Create JSON Schema for variant-centered views.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -609,6 +609,15 @@
           },
           "uniqueItems": true
         },
+        "panels": {
+          "description": "List of panels.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Panel"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "variants": {
           "description": "List of variants detected in this panel.",
           "type": "array",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1122,6 +1122,15 @@
         "name": {
           "$ref": "#/$defs/VariantName"
         },
+        "aliases": {
+          "description": "List of variant aliases.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VariantAlias"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "genes": {
           "description": "List of genes overlapping with this variant.",
           "type": "array",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1263,6 +1263,37 @@
         }
       ]
     },
+    "VariantAlias": {
+      "type": "object",
+      "properties": {
+        "ref_seq": {
+          "$ref": "#/$defs/RefSeq"
+        },
+        "name": {
+          "$ref": "#/$defs/VariantName"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DbXRef"
+          },
+          "uniqueItems": true
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Comment"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "ref_seq",
+        "name"
+      ]
+    },
     "VariantDetection": {
       "description": "The technique(s) that were used to detect the variant.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1183,6 +1183,7 @@
       "additionalProperties": false,
       "required": [
         "type",
+        "ref_seq",
         "name"
       ],
       "examples": [

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/VarioML/VarioML/json/schemas/v.2.0/LSDB.json",
+  "$id": "https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/LSDB.json",
   "title": "Locus Specific Database (LSDB)",
   "description": "An LSDB object holds one or more data submissions based around either individuals, their phenotypes, and their variants, or a summary submission of just variant data.",
   "type": "object",

--- a/json/schemas/v.2.0/variant.json
+++ b/json/schemas/v.2.0/variant.json
@@ -3,5 +3,63 @@
   "$id": "https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/variant.json",
   "title": "Variant",
   "description": "A genomic variant, as an aggregated entry for multiple observations. Observations can either be full submissions with an individual, or reports only containing the variant.",
-  "type": "object"
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of variant (DNA, cDNA, RNA, AA). For genomic variants, only 'DNA' is allowed.",
+      "type": "string",
+      "enum": ["DNA"]
+    },
+    "ref_seq": {
+      "$ref": "LSDB.json#/$defs/RefSeq"
+    },
+    "name": {
+      "$ref": "LSDB.json#/$defs/VariantName"
+    },
+    "aliases": {
+      "description": "List of variant aliases.",
+      "type": "array",
+      "items": {
+        "$ref": "LSDB.json#/$defs/VariantAlias"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "genes": {
+      "description": "List of genes overlapping with this variant.",
+      "type": "array",
+      "items": {
+        "$ref": "LSDB.json#/$defs/Gene"
+      },
+      "uniqueItems": true
+    },
+    "pathogenicities": {
+      "description": "List of variant classifications.",
+      "type": "array",
+      "items": {
+        "$ref": "LSDB.json#/$defs/Pathogenicity"
+      }
+    },
+    "db_xrefs": {
+      "description": "List of database cross references.",
+      "type": "array",
+      "items": {
+        "$ref": "LSDB.json#/$defs/DbXRef"
+      },
+      "uniqueItems": true
+    },
+    "comments": {
+      "description": "List of comments.",
+      "type": "array",
+      "items": {
+        "$ref": "LSDB.json#/$defs/Comment"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "ref_seq",
+    "name"
+  ]
 }

--- a/json/schemas/v.2.0/variant.json
+++ b/json/schemas/v.2.0/variant.json
@@ -40,6 +40,9 @@
         "$ref": "LSDB.json#/$defs/Pathogenicity"
       }
     },
+    "panel": {
+      "$ref": "LSDB.json#/$defs/Panel"
+    },
     "db_xrefs": {
       "description": "List of database cross references.",
       "type": "array",

--- a/json/schemas/v.2.0/variant.json
+++ b/json/schemas/v.2.0/variant.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/variant.json",
+  "title": "Variant",
+  "description": "A genomic variant, as an aggregated entry for multiple observations. Observations can either be full submissions with an individual, or reports only containing the variant.",
+  "type": "object"
+}


### PR DESCRIPTION
## Create JSON Schema for variant-centered views.

### Adapted LSDB Schema to prepare.
- Fix `$id` to link to the actual file location.
- Allow Panels to contain Panels.
- Define the VariantAlias element.
  - This element is based on `VmlRelatedVariant`, but has been simplified.
- Add aliases to the Variant object.
  - Here, we'll be able to store mappings on other genome builds or known alternative descriptions.
- Add the `ref_seq` object to be required for the Variant object.

### Added the Variant JSON Schema.
- Add the Variant JSON Schema for aggregated variant data.
  - Add the basic attributes also found in the Variant object, plus the ability to store a Panel. This is where the actual submissions will go. Individuals, Panels, and simple Variant observations can all be stored in the Panel object.

Closes #20.