### PR TITLE
Define a Contact's email address as a string or an array.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -227,7 +227,17 @@
         },
         "email": {
           "description": "The email address of the contact person.",
-          "type": "string"
+          "oneOf": [
+            {
+              "type" : "string"
+            },
+            {
+              "type" : "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "db_xrefs": {
           "description": "List of database cross references.",


### PR DESCRIPTION
Define a Contact's email address as a string or an array.
This allows the definition of more than one email address per Contact without the need for parsing (separation with semicolons or so).