### PR TITLE
Define the Genetic Origin object and add it as an attribute to the Variant object.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1320,6 +1320,9 @@
           "minItems": 1,
           "uniqueItems": true
         },
+        "genetic_origin": {
+          "$ref": "#/$defs/GeneticOrigin"
+        },
         "genes": {
           "description": "List of genes overlapping with this variant.",
           "type": "array",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -365,6 +365,55 @@
         "accession": "source"
       }
     },
+    "EvidenceCode": {
+      "description": "An ontology term (i.e. has optional source and accession attributes), which provides information related to the validity or the quality of an observation.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string",
+          "enum": ["confirmed", "inferred"]
+        },
+        "description": {
+          "description": "A longer description of the term.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DbXRef"
+          },
+          "uniqueItems": true
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Comment"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "dependencies": {
+        "accession": "source"
+      }
+    },
     "Gender": {
       "description": "The gender of an individual.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -519,6 +519,84 @@
         }
       ]
     },
+    "GeneticOrigin": {
+      "description": "The genetic origin of a variant (inherited, de novo, etc), together with GeneticSource corresponding with the Sequence Ontology's variant_origin.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string",
+          "enum": ["de novo", "inherited", "somatic"]
+        },
+        "description": {
+          "description": "A longer description of the term.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "genetic_source": {
+          "$ref": "#/$defs/GeneticSource"
+        },
+        "evidence_code": {
+          "$ref": "#/$defs/EvidenceCode"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DbXRef"
+          },
+          "uniqueItems": true
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Comment"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "dependencies": {
+        "accession": "source"
+      },
+      "examples": [
+        {
+          "term": "inherited",
+          "genetic_source": {
+            "term": "paternal",
+            "evidence_code": {
+              "term": "inferred"
+            }
+          }
+        },
+        {
+          "term": "inherited",
+          "genetic_source": {
+            "term": "maternal",
+            "evidence_code": {
+              "term": "confirmed"
+            }
+          }
+        },
+        {
+          "term": "de novo"
+        }
+      ]
+    },
     "GeneticSource": {
       "description": "Source of variant (paternal, maternal), together with GeneticOrigin corresponding with the Sequence Ontology's variant_origin.",
       "type": "object",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -519,6 +519,58 @@
         }
       ]
     },
+    "GeneticSource": {
+      "description": "Source of variant (paternal, maternal), together with GeneticOrigin corresponding with the Sequence Ontology's variant_origin.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "The term that can be considered as the value of the element.",
+          "type": "string",
+          "enum": ["maternal", "paternal"]
+        },
+        "description": {
+          "description": "A longer description of the term.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Name of an external resource.",
+          "type": "string"
+        },
+        "accession": {
+          "description": "The ID of a relevant entry in an external resource. If given, 'source' is mandatory.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI to a relevant entry in an external resource.",
+          "type": "string"
+        },
+        "evidence_code": {
+          "$ref": "#/$defs/EvidenceCode"
+        },
+        "db_xrefs": {
+          "description": "List of database cross references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DbXRef"
+          },
+          "uniqueItems": true
+        },
+        "comments": {
+          "description": "List of comments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Comment"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ],
+      "dependencies": {
+        "accession": "source"
+      }
+    },
     "Individual": {
       "description": "A patient or other individual.",
       "type": "object",


### PR DESCRIPTION
Define the Genetic Origin object and add it as an attribute to the Variant object.
- Add definition of EvidenceCode object.
- Add definition of GeneticSource object.
- Add definition of GeneticOrigin object, including examples.
- Add the `genetic_origin` attribute to the Variant object.