### PR TITLE
Fix the DataSource object.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -876,6 +876,9 @@
             "$ref": "#/$defs/Phenotype"
           },
           "uniqueItems": true
+        },
+        "data_source": {
+          "$ref": "#/$defs/DataSource"
         }
       },
       "additionalProperties": false,

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -51,13 +51,13 @@
       "minItems": 1,
       "uniqueItems": true
     },
-    "source": {
-      "$ref": "#/$defs/Source"
+    "data_source": {
+      "$ref": "#/$defs/DataSource"
     }
   },
   "additionalProperties": false,
   "required": [
-    "source"
+    "data_source"
   ],
   "oneOf": [
     {
@@ -696,8 +696,8 @@
           "minItems": 1,
           "uniqueItems": true
         },
-        "source": {
-          "$ref": "#/$defs/Source"
+        "data_source": {
+          "$ref": "#/$defs/DataSource"
         },
         "sharing_policy": {
           "$ref": "#/$defs/SharingPolicy"
@@ -820,8 +820,8 @@
           "minItems": 1,
           "uniqueItems": true
         },
-        "source": {
-          "$ref": "#/$defs/Source"
+        "data_source": {
+          "$ref": "#/$defs/DataSource"
         },
         "sharing_policy": {
           "$ref": "#/$defs/SharingPolicy"
@@ -1161,7 +1161,7 @@
         "variants"
       ]
     },
-    "Source": {
+    "DataSource": {
       "description": "Contains information on the data source. Typically specifies the source database, although the system, organization, or institution from which the data has been exported can also be used.",
       "type": "object",
       "properties": {
@@ -1205,7 +1205,7 @@
       ],
       "examples": [
         {
-          "source": {
+          "data_source": {
             "contacts": [
               {
                 "role": "submitter",
@@ -1377,8 +1377,8 @@
         "seq_changes": {
           "$ref": "#/$defs/SeqChanges"
         },
-        "source": {
-          "$ref": "#/$defs/Source"
+        "data_source": {
+          "$ref": "#/$defs/DataSource"
         },
         "sharing_policy": {
           "$ref": "#/$defs/SharingPolicy"


### PR DESCRIPTION
Fix the `DataSource` object.
- Rename Source to DataSource to prevent clashes.
  - The original VarioML reuses the term `source` for three different things. It was used for a genetic source (now renamed to `genetic_source` in JSON Schema), for a data source, and for providing a source to an accession. Now renaming the `Source` object to `DataSource` and renaming its mentions to `data_source` to prevent problems with clashes with the accession sources.  This allows us to add `data_source` to an object that already has accession and source elements.
- Add `data_source` to the `Pathogenicities` object. LOVD can store pathogenicities from multiple sources. Especially for the aggregate `Variant` object, pathogenicities can come from many sources (different submitters and the curator). We need to be able to tell the data consumer where these values come from.