### PR TITLE
Improve the JSON schema after feedback.

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -33,7 +33,6 @@
       "items": {
         "$ref": "#/$defs/Individual"
       },
-      "minItems": 1,
       "uniqueItems": true
     },
     "panels": {
@@ -42,7 +41,6 @@
       "items": {
         "$ref": "#/$defs/Panel"
       },
-      "minItems": 1,
       "uniqueItems": true
     },
     "variants": {
@@ -51,7 +49,6 @@
       "items": {
         "$ref": "#/$defs/Variant"
       },
-      "minItems": 1,
       "uniqueItems": true
     },
     "data_source": {
@@ -801,7 +798,6 @@
           "items": {
             "$ref": "#/$defs/Variant"
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "data_source": {
@@ -940,7 +936,6 @@
           "items": {
             "$ref": "#/$defs/Individual"
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "phenotypes": {
@@ -957,7 +952,6 @@
           "items": {
             "$ref": "#/$defs/Panel"
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "variants": {
@@ -966,7 +960,6 @@
           "items": {
             "$ref": "#/$defs/Variant"
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "data_source": {

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -596,6 +596,14 @@
           "description": "URI to a relevant entry in an external resource.",
           "type": "string"
         },
+        "phenotypes": {
+          "description": "List of phenotypes associated to this gene.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Phenotype"
+          },
+          "uniqueItems": true
+        },
         "db_xrefs": {
           "description": "List of database cross references.",
           "type": "array",


### PR DESCRIPTION
#### Improve the JSON schema after feedback.
- Remove the minItems requirement from a few arrays.
  - Always requiring individuals, panels, and variants to have at least one entry or otherwise be empty makes it impossible to store certain data, like individuals where no variant was identified.
  - It makes the code to generate the format unnecessarily complicated.
  - Cleaning the data using tools like `jq` becomes very difficult.
  - The only downside, in reality, is that it takes a bit more bandwidth to include empty arrays, but we'll leave that to the implementers.
- Allow genes to store phenotype relationships. This feature was requested, since gene-phenotype relationships may be stored differently than just through variants and individuals (like in LOVD) and otherwise, we wouldn't be able to get this data out.