### PR TITLE
Add GA4GH JSON Schema.

### DIFF
--- a/json/schemas/v.2.0/GA4GH.json
+++ b/json/schemas/v.2.0/GA4GH.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/GA4GH.json",
+  "title": "GA4GH Data Connect API",
+  "description": "Paginated output of the GA4GH Data Connect API, bearing data formatted in VarioML.",
+  "type": "object",
+  "properties": {
+    "data_model": {
+      "$ref": "http://json-schema.org/draft-07/schema#"
+    },
+    "data": {
+      "description": "Page of JSON objects, each adhering to the schema given in the `data_model` property.",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "pagination": {
+      "description": "Object allowing linking to the next page of JSON objects. This object is absent on the last page.",
+      "type": "object",
+      "properties": {
+        "next_page_url": {
+          "description": "URL pointing to the next page of data.",
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "additionalProperties": false
+    },
+    "errors": {
+      "description": "List of errors encountered.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "title": {
+            "description": "A short, human-readable description of the error. The value should not change from occurrence to occurrence of an error, except for purposes of localization.",
+            "type": "string",
+            "examples": [
+              "Internal server error"
+            ]
+          },
+          "detail": {
+            "description": "A human-readable explanation specific to this occurrence of the error.",
+            "type": "string",
+            "examples": [
+              "Internal server error"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "title"
+        ]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "data_model",
+    "data"
+  ],
+  "oneOf": [
+    {
+      "properties": {
+        "data_model": {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "const": "https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/variant.json"
+            }
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "variant.json"
+          }
+        }
+      }
+    }
+  ]
+}
+

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -584,7 +584,7 @@
             },
             {
               "type": "integer",
-              "exclusiveMinimum": 0
+              "minimum": 1
             }
           ]
         },
@@ -913,7 +913,7 @@
         "size": {
           "description": "The number of individuals in this panel.",
           "type": "integer",
-          "exclusiveMinimum": 0
+          "minimum": 1
         },
         "type": {
           "description": "The type of panel; family, extended family, or a population.",

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1639,7 +1639,7 @@
         "template": {
           "description": "The template on which the variant was detected.",
           "type": "string",
-          "enum": ["DNA", "RNA", "protein"]
+          "enum": ["DNA", "RNA", "protein", "?"]
         },
         "technique": {
           "description": "The detection method.",


### PR DESCRIPTION
#### Add GA4GH JSON Schema.
- Add a schema for the GA4GH Data Connect API.
  - The schema is based on the validation information found on the GA4GH Data Connect GitHub repository.
  - Our implementation can currently only hold variant data; other formats can be added later quite simply.
  - Now that we have a GA4GH schema file, we can simply validate our GA4GH output using this schema.

#### Also:
- Allow "?" as a valid value for `variant_detection > template`. LOVD sometimes provides this value.
- Remove the use of `exclusiveMinimum` and use `minimum`, instead. This improves backward compatibility as not all validation tools support the later JSON Schema standards. This makes our schema compatible with JSON Schema draft 4, the supported version of the `php-json-schema` library.