### PR TITLE
Add `EvidenceCode` for a `Variant`

### DIFF
--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1527,6 +1527,20 @@
         },
         "modification_date": {
           "$ref": "#/$defs/DateTime"
+        },
+        "evidence_code": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/EvidenceCode"
+            },
+            {
+              "properties": {
+                "term": {
+                  "enum": ["classification_record", "in_vitro", "summary_record"]
+                }
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false,

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1549,6 +1549,27 @@
         "ref_seq",
         "name"
       ],
+      "if": {
+        "properties": {
+          "evidence_code": {
+            "properties": {
+              "term": {
+                "enum": ["classification_record", "in_vitro", "summary_record"]
+              }
+            }
+          }
+        },
+        "required": [
+          "evidence_code"
+        ]
+      },
+      "then": {
+        "not": {
+          "required": [
+            "genetic_origin"
+          ]
+        }
+      },
       "examples": [
         {
           "copy_count": 1,

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -1536,7 +1536,7 @@
             {
               "properties": {
                 "term": {
-                  "enum": ["classification_record", "in_vitro", "summary_record"]
+                  "enum": ["classification_record", "in_silico", "in_vitro", "summary_record"]
                 }
               }
             }
@@ -1554,7 +1554,7 @@
           "evidence_code": {
             "properties": {
               "term": {
-                "enum": ["classification_record", "in_vitro", "summary_record"]
+                "enum": ["classification_record", "in_silico", "in_vitro", "summary_record"]
               }
             }
           }

--- a/json/schemas/v.2.0/LSDB.json
+++ b/json/schemas/v.2.0/LSDB.json
@@ -480,8 +480,7 @@
       "properties": {
         "term": {
           "description": "The term that can be considered as the value of the element.",
-          "type": "string",
-          "enum": ["confirmed", "inferred"]
+          "type": "string"
         },
         "description": {
           "description": "A longer description of the term.",
@@ -665,7 +664,18 @@
           "$ref": "#/$defs/GeneticSource"
         },
         "evidence_code": {
-          "$ref": "#/$defs/EvidenceCode"
+          "allOf": [
+            {
+              "$ref": "#/$defs/EvidenceCode"
+            },
+            {
+              "properties": {
+                "term": {
+                  "enum": ["confirmed", "inferred"]
+                }
+              }
+            }
+          ]
         },
         "db_xrefs": {
           "description": "List of database cross references.",
@@ -740,7 +750,18 @@
           "type": "string"
         },
         "evidence_code": {
-          "$ref": "#/$defs/EvidenceCode"
+          "allOf": [
+            {
+              "$ref": "#/$defs/EvidenceCode"
+            },
+            {
+              "properties": {
+                "term": {
+                  "enum": ["confirmed", "inferred"]
+                }
+              }
+            }
+          ]
         },
         "db_xrefs": {
           "description": "List of database cross references.",


### PR DESCRIPTION
## Add EvidenceCode for a Variant
Although the XML model already allowed for this, the JSON implementation hadn't implemented this yet. The `EvidenceCode` element was used in the `GeneticOrigin` and the `GeneticSource` elements, to indicate whether the values on those elements were confirmed or inferred.

### Classification, _in silico_, _in vitro_, and summary records
LOVD has classification, _in silico_, _in vitro_, and summary records. These are variant records not representing variant observations from a patient, but rather variants classified by a group or consortium, _in silico_ variant effect analysis, variants analyzed in cell culture, or a curator's interpretation of all available data on a certain variant. To allow the representation of these records in VarioML, we add the `EvidenceCode` element to the `Variant` element.

### Changes
- Move the required values for `EvidenceCode`'s `term` up one level. This allows us to use `EvidenceCode` in other places as well, with different `term`s.
- Add the `EvidenceCode` element to the `Variant` element. This allows users to indicate a record's validity or quality. Current allowed terms are: "classification_record", "in_silico", "in_vitro", and "summary_record".
- If a `Variant`'s `EvidenceCode` is given, disallow `GeneticOrigin`. This rule is linked to the current `EvidenceCode` values, so that any possible future values for `EvidenceCode` might still allow for `GeneticOrigin` to be present.